### PR TITLE
Movable ink url

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -1,5 +1,5 @@
 require 'sinatra'
-require_relative 'awyiss'
+require_relative 'slackbot_awyiss'
 
 post '/awyiss' do
   SlackBot::AwYiss.new(params[:channel_id], params[:text]).post_to_slack

--- a/awyiss.rb
+++ b/awyiss.rb
@@ -2,6 +2,7 @@ require "slack-ruby-client"
 require "net/http"
 require "uri"
 require "json"
+require "cgi"
 
 puts "WARNING!!! awyisser tweets all your yisses to @awyisser, so maybe don't put anything you don't want tweeted?"
 
@@ -26,11 +27,30 @@ module AwYisser
   def get_image(phrase)
     params = {"phrase" => phrase}
     params["sfw"] = true if sfw # required to only add sfw key conditionally because {"sfw" => false} still registers as true
-    response = httpPostRequest(URL, params)
+    #post_to_awyisser(params)
+    direct_image_link(params)
+  end
+
+  def direct_image_link(params)
+    "#{URL}?#{parameterize(params)}"
+  end
+
+  def parameterize(params)
+    encoded_params = params.collect do |k,v|
+      if v.is_a? String
+        v = CGI::escape(v)
+      end
+      "#{k}=#{v}"
+    end
+    encoded_params.join('&')
+  end
+
+  def post_to_awyisser(params)
+    response = http_post_request(URL, params)
     JSON.parse(response.body)["link"]
   end
 
-  def httpPostRequest(url, data)
+  def http_post_request(url, data)
     uri = URI.parse(url)
     http = Net::HTTP.new(uri.host, uri.port)
     request = Net::HTTP::Post.new(uri.request_uri)

--- a/awyiss.rb
+++ b/awyiss.rb
@@ -57,6 +57,7 @@ class SlackBot
     end
 
     def message
+      # return maintenance_message
       case text.strip
         when /^awyiss\ssfw\s(\S.+)/
           @sfw = true
@@ -67,6 +68,10 @@ class SlackBot
         else
           "wut?"
       end
+    end
+
+    def maintenance_message
+      "aw nooo... maintenance until further notice ( ᵒ̴̶̷̥́ _ᵒ̴̶̷̣̥̀ )"
     end
   end
 end

--- a/awyiss.rb
+++ b/awyiss.rb
@@ -18,10 +18,7 @@ module AwYisser
     if phrase.length > 40
       return "aw nooo... your phrase is too long! (40 chars max)"
     end
-    if sfw
-      return "aw yiss motha flippin #{phrase} #{get_image(phrase)}"
-    end
-    "aw yiss motha fuckin #{phrase} #{get_image(phrase)}"
+    "#{get_image(phrase)}"
   end
 
   def get_image(phrase)

--- a/awyiss.rb
+++ b/awyiss.rb
@@ -11,6 +11,43 @@ Slack.configure do |config|
   fail 'Missing ENV[SLACK_API_TOKEN]!' unless config.token
 end
 
+class SlackBot
+  class AwYiss
+    include AwYisser
+
+    attr_reader :sfw, :text
+
+    def initialize(channel, text)
+      @channel = channel
+      @text = text
+      @sfw = false
+      @client = Slack::Web::Client.new
+    end
+
+    def post_to_slack
+      @client.chat_postMessage(channel: @channel, text: message, as_user: true)
+    end
+
+    def message
+      # return maintenance_message
+      case text.strip
+        when /^(awyiss||aw\syiss||aww\syiss)\ssfw\s(\S.?+)/
+          @sfw = true
+          awyissify($2)
+        when /^(awyiss||aw\syiss||aww\syiss)\s(\S.?+)/
+          @sfw = false
+          awyissify($2)
+        else
+          "wut?"
+      end
+    end
+
+    def maintenance_message
+      "aw nooo... maintenance until further notice ( ᵒ̴̶̷̥́ _ᵒ̴̶̷̣̥̀ )"
+    end
+  end
+end
+
 module AwYisser
   URL = ["http://awyisser.com/api/generator", "http://ink1001.com/p/lp/116570e1643601f3.png"]
 
@@ -47,42 +84,5 @@ module AwYisser
     request = Net::HTTP::Post.new(uri.request_uri)
     request.set_form_data(data)
     http.request(request)
-  end
-end
-
-class SlackBot
-  class AwYiss
-    include AwYisser
-
-    attr_reader :sfw, :text
-
-    def initialize(channel, text)
-      @channel = channel
-      @text = text
-      @sfw = false
-      @client = Slack::Web::Client.new
-    end
-
-    def post_to_slack
-      @client.chat_postMessage(channel: @channel, text: message, as_user: true)
-    end
-
-    def message
-      # return maintenance_message
-      case text.strip
-        when /^(awyiss||aw\syiss||aww\syiss)\ssfw\s(\S.?+)/
-          @sfw = true
-          awyissify($2)
-        when /^(awyiss||aw\syiss||aww\syiss)\s(\S.?+)/
-          @sfw = false
-          awyissify($2)
-        else
-          "wut?"
-      end
-    end
-
-    def maintenance_message
-      "aw nooo... maintenance until further notice ( ᵒ̴̶̷̥́ _ᵒ̴̶̷̣̥̀ )"
-    end
   end
 end

--- a/awyiss.rb
+++ b/awyiss.rb
@@ -81,10 +81,10 @@ class SlackBot
       case text.strip
         when /^(awyiss||aw\syiss||aww\syiss)\ssfw\s(\S.?+)/
           @sfw = true
-          awyissify($1)
+          awyissify($2)
         when /^(awyiss||aw\syiss||aww\syiss)\s(\S.?+)/
           @sfw = false
-          awyissify($1)
+          awyissify($2)
         else
           "wut?"
       end

--- a/awyiss.rb
+++ b/awyiss.rb
@@ -4,7 +4,7 @@ require "uri"
 require "json"
 require "cgi"
 
-puts "WARNING!!! awyisser tweets all your yisses to @awyisser, so maybe don't put anything you don't want tweeted?"
+puts "WARNING!!! awyisser may tweet your yisses to @awyisser, so maybe don't put anything you don't want tweeted?"
 
 Slack.configure do |config|
   config.token = ENV['SLACK_API_TOKEN']
@@ -12,24 +12,23 @@ Slack.configure do |config|
 end
 
 module AwYisser
-  URL = "http://ink1001.com/p/lp/116570e1643601f3.png"
+  URL = ["http://awyisser.com/api/generator", "http://ink1001.com/p/lp/116570e1643601f3.png"]
 
   def awyissify(phrase)
     if phrase.length > 40
       return "aw nooo... your phrase is too long! (40 chars max)"
     end
-    "#{get_image(phrase)}"
+    "#{get_image(phrase, false)}"
   end
 
-  def get_image(phrase)
+  def get_image(phrase, use_awyisser_dot_com)
     params = {"phrase" => phrase}
     params["sfw"] = true if sfw # required to only add sfw key conditionally because {"sfw" => false} still registers as true
-    #post_to_awyisser(params)
-    direct_image_link(params)
-  end
-
-  def direct_image_link(params)
-    "#{URL}?#{parameterize(params)}"
+    if use_awyisser_dot_com
+      response = http_post_request(URL[0], params)
+      return JSON.parse(response.body)["link"]
+    end
+    "#{URL[1]}?#{parameterize(params)}"
   end
 
   def parameterize(params)
@@ -40,11 +39,6 @@ module AwYisser
       "#{k}=#{v}"
     end
     encoded_params.join('&')
-  end
-
-  def post_to_awyisser(params)
-    response = http_post_request(URL, params)
-    JSON.parse(response.body)["link"]
   end
 
   def http_post_request(url, data)

--- a/awyiss.rb
+++ b/awyiss.rb
@@ -11,7 +11,7 @@ Slack.configure do |config|
 end
 
 module AwYisser
-  URL = "http://awyisser.com/api/generator"
+  URL = "http://ink1001.com/p/lp/116570e1643601f3.png"
 
   def awyissify(phrase)
     if phrase.length > 40

--- a/awyiss.rb
+++ b/awyiss.rb
@@ -79,10 +79,10 @@ class SlackBot
     def message
       # return maintenance_message
       case text.strip
-        when /^awyiss\ssfw\s(\S.+)/
+        when /^(awyiss||aw\syiss||aww\syiss)\ssfw\s(\S.?+)/
           @sfw = true
           awyissify($1)
-        when /^awyiss\s(\S.+)/
+        when /^(awyiss||aw\syiss||aww\syiss)\s(\S.?+)/
           @sfw = false
           awyissify($1)
         else

--- a/awyisser.rb
+++ b/awyisser.rb
@@ -6,17 +6,19 @@ require "cgi"
 module AwYisser
   URL = ["http://awyisser.com/api/generator", "http://ink1001.com/p/lp/116570e1643601f3.png"]
 
+  USE_AWYISSER_DOT_COM = false
+
   def awyissify(phrase)
     if phrase.length > 40
       return "aw nooo... your phrase is too long! (40 chars max)"
     end
-    "#{get_image(phrase, false)}"
+    "#{get_image(phrase)}"
   end
 
-  def get_image(phrase, use_awyisser_dot_com)
+  def get_image(phrase)
     params = {"phrase" => phrase}
     params["sfw"] = true if sfw # required to only add sfw key conditionally because {"sfw" => false} still registers as true
-    if use_awyisser_dot_com
+    if USE_AWYISSER_DOT_COM
       response = http_post_request(URL[0], params)
       return JSON.parse(response.body)["link"]
     end

--- a/awyisser.rb
+++ b/awyisser.rb
@@ -1,52 +1,7 @@
-require "slack-ruby-client"
 require "net/http"
 require "uri"
 require "json"
 require "cgi"
-
-puts "WARNING!!! awyisser may tweet your yisses to @awyisser, so maybe don't put anything you don't want tweeted?"
-
-Slack.configure do |config|
-  config.token = ENV['SLACK_API_TOKEN']
-  fail 'Missing ENV[SLACK_API_TOKEN]!' unless config.token
-end
-
-class SlackBot
-  class AwYiss
-    include AwYisser
-
-    attr_reader :sfw, :text
-
-    def initialize(channel, text)
-      @channel = channel
-      @text = text
-      @sfw = false
-      @client = Slack::Web::Client.new
-    end
-
-    def post_to_slack
-      @client.chat_postMessage(channel: @channel, text: message, as_user: true)
-    end
-
-    def message
-      # return maintenance_message
-      case text.strip
-        when /^(awyiss||aw\syiss||aww\syiss)\ssfw\s(\S.?+)/
-          @sfw = true
-          awyissify($2)
-        when /^(awyiss||aw\syiss||aww\syiss)\s(\S.?+)/
-          @sfw = false
-          awyissify($2)
-        else
-          "wut?"
-      end
-    end
-
-    def maintenance_message
-      "aw nooo... maintenance until further notice ( ᵒ̴̶̷̥́ _ᵒ̴̶̷̣̥̀ )"
-    end
-  end
-end
 
 module AwYisser
   URL = ["http://awyisser.com/api/generator", "http://ink1001.com/p/lp/116570e1643601f3.png"]

--- a/slackbot_awyiss.rb
+++ b/slackbot_awyiss.rb
@@ -28,10 +28,10 @@ class SlackBot
     def message
       # return maintenance_message
       case text.strip
-        when /^(awyiss||aw\syiss||aww\syiss)\ssfw\s(\S.?+)/
+        when /^(awyiss||aw\syiss||aww\syiss)\ssfw\s(\S.+)/
           @sfw = true
           awyissify($2)
-        when /^(awyiss||aw\syiss||aww\syiss)\s(\S.?+)/
+        when /^(awyiss||aw\syiss||aww\syiss)\s(\S.+)/
           @sfw = false
           awyissify($2)
         else

--- a/slackbot_awyiss.rb
+++ b/slackbot_awyiss.rb
@@ -1,0 +1,46 @@
+require "slack-ruby-client"
+require_relative "awyisser"
+
+puts "WARNING!!! awyisser may tweet your yisses to @awyisser, so maybe don't put anything you don't want tweeted?"
+
+Slack.configure do |config|
+  config.token = ENV['SLACK_API_TOKEN']
+  fail 'Missing ENV[SLACK_API_TOKEN]!' unless config.token
+end
+
+class SlackBot
+  class AwYiss
+    include AwYisser
+
+    attr_reader :sfw, :text
+
+    def initialize(channel, text)
+      @channel = channel
+      @text = text
+      @sfw = false
+      @client = Slack::Web::Client.new
+    end
+
+    def post_to_slack
+      @client.chat_postMessage(channel: @channel, text: message, as_user: true)
+    end
+
+    def message
+      # return maintenance_message
+      case text.strip
+        when /^(awyiss||aw\syiss||aww\syiss)\ssfw\s(\S.?+)/
+          @sfw = true
+          awyissify($2)
+        when /^(awyiss||aw\syiss||aww\syiss)\s(\S.?+)/
+          @sfw = false
+          awyissify($2)
+        else
+          "wut?"
+      end
+    end
+
+    def maintenance_message
+      "aw nooo... maintenance until further notice ( ᵒ̴̶̷̥́ _ᵒ̴̶̷̣̥̀ )"
+    end
+  end
+end

--- a/slackbot_awyiss.rb
+++ b/slackbot_awyiss.rb
@@ -28,10 +28,10 @@ class SlackBot
     def message
       # return maintenance_message
       case text.strip
-        when /^(awyiss||aw\syiss||aww\syiss)\ssfw\s(\S.+)/
+        when /^(awyiss||aw\syiss||awwyiss||aww\syiss)\ssfw\s(\S.+)/
           @sfw = true
           awyissify($2)
-        when /^(awyiss||aw\syiss||aww\syiss)\s(\S.+)/
+        when /^(awyiss||aw\syiss||awwyiss||aww\syiss)\s(\S.+)/
           @sfw = false
           awyissify($2)
         else


### PR DESCRIPTION
Improvements to the bot:
- allows the `aw yiss` and `aww yiss` hook.
- uses aw yiss image generated from a Movable Ink webcrop instead of the awyisser service so that the phrases aren't tweeted out.
- reorganizes code a bit for readability.
